### PR TITLE
FIX: When an exception is raised during castcall method, notify caller

### DIFF
--- a/lib/ultravisor/child/call.rb
+++ b/lib/ultravisor/child/call.rb
@@ -7,6 +7,9 @@ class Ultravisor::Child::Call
 
 	def go!(receiver)
 		@rv_q << receiver.__send__(@method_name, *@args, &@blk)
+	rescue Exception => ex
+		@rv_q << @rv_fail
+	ensure
 		@rv_q.close
 	end
 


### PR DESCRIPTION
Previously the caller would never receive any notification that the
child had failed, and would block forever. This commit treats a failure
during the call the same way as a failure while the call is queuing.